### PR TITLE
include datasetid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 python:
-  - '2.7'
+  - '3.7'
 
 jobs:
   include:
@@ -13,37 +13,23 @@ jobs:
       install:
         - pip install -U flake8 flake8-import-order
       script:
-        - flake8 tripal test --ignore=E501
-    - stage: test
-      python: '2.7'
-      install:
-        - pip install -U pip setuptools nose
-        - python setup.py install
-        - export BM2G_GLOBAL_CONFIG_PATH=`pwd`/test-data/bm2g.yml
-        - GAL_DOCKER=$(docker run -d -p 8080:80 -e GALAXY_CONFIG_ALLOW_LIBRARY_PATH_PASTE=True -v `pwd`/test-data/:/data/ quay.io/bgruening/galaxy:19.09)
-        - sleep 180 # Wait for the container to be ready
-        - docker exec -i $GAL_DOCKER install-tools /data/tools.yml
-        - "docker exec -i $GAL_DOCKER supervisorctl restart galaxy:"
-        - python setup.py nosetests || true # it will probably fail the first time, who cares?
-        - "docker exec -i $GAL_DOCKER supervisorctl restart galaxy:"
-      script:
-        - python setup.py nosetests
-    - stage: test
-      python: '3.5'
-      install:
-        - pip install -U pip setuptools nose
-        - python setup.py install
-        - export BM2G_GLOBAL_CONFIG_PATH=`pwd`/test-data/bm2g.yml
-        - GAL_DOCKER=$(docker run -d -p 8080:80 -e GALAXY_CONFIG_ALLOW_LIBRARY_PATH_PASTE=True -v `pwd`/test-data/:/data/ quay.io/bgruening/galaxy:19.09)
-        - sleep 180 # Wait for the container to be ready
-        - docker exec -i $GAL_DOCKER install-tools /data/tools.yml
-        - "docker exec -i $GAL_DOCKER supervisorctl restart galaxy:"
-        - python setup.py nosetests || true # it will probably fail the first time, who cares?
-        - "docker exec -i $GAL_DOCKER supervisorctl restart galaxy:"
-      script:
-        - python setup.py nosetests
+        - flake8 biomaj2galaxy test --ignore=E501
     - stage: test
       python: '3.6'
+      install:
+        - pip install -U pip setuptools nose
+        - python setup.py install
+        - export BM2G_GLOBAL_CONFIG_PATH=`pwd`/test-data/bm2g.yml
+        - GAL_DOCKER=$(docker run -d -p 8080:80 -e GALAXY_CONFIG_ALLOW_LIBRARY_PATH_PASTE=True -v `pwd`/test-data/:/data/ quay.io/bgruening/galaxy:19.09)
+        - sleep 180 # Wait for the container to be ready
+        - docker exec -i $GAL_DOCKER install-tools /data/tools.yml
+        - "docker exec -i $GAL_DOCKER supervisorctl restart galaxy:"
+        - python setup.py nosetests || true # it will probably fail the first time, who cares?
+        - "docker exec -i $GAL_DOCKER supervisorctl restart galaxy:"
+      script:
+        - python setup.py nosetests
+    - stage: test
+      python: '3.7
       install:
         - pip install -U pip setuptools nose
         - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       script:
         - python setup.py nosetests
     - stage: test
-      python: '3.7
+      python: '3.7'
       install:
         - pip install -U pip setuptools nose
         - python setup.py install

--- a/biomaj2galaxy/cli.py
+++ b/biomaj2galaxy/cli.py
@@ -1,5 +1,6 @@
 from biomaj2galaxy import __version__
 from biomaj2galaxy import pass_context
+
 import click
 
 from .commands.add import add as func0
@@ -7,7 +8,6 @@ from .commands.add_lib import add_lib as func2
 from .commands.init import init as func4
 from .commands.rm import rm as func1
 from .commands.rm_lib import rm_lib as func3
-
 from .config import get_instance, global_config_path, set_global_config_path
 
 

--- a/biomaj2galaxy/commands/add.py
+++ b/biomaj2galaxy/commands/add.py
@@ -200,7 +200,11 @@ def add(ctx, files, dbkey, dbkey_display_name, genome_fasta, genome_fasta_name, 
                 params['sorting|sequence_identifiers_' + n + '|identifier'] = i
                 n += 1
         fetch_res = ctx.gi.tools.run_tool(None, ADD_FASTA_TOOL_ID, params)
-        wait_completion(ctx.gi, fetch_res['outputs'][0]['id'])
+        datasetid = fetch_res['outputs'][0]['id']
+        jobid = None
+        if 'jobs' in fetch_res :
+          jobid=fetch_res['jobs'][0]['id']
+        wait_completion(ctx.gi, datasetid, jobid)
 
     elif create_dbkey:  # Create the dbkey without ref genome (no len computing)
         print("Will create the dbkey '" + dbkey + "'")
@@ -248,7 +252,11 @@ def add(ctx, files, dbkey, dbkey_display_name, genome_fasta, genome_fasta_name, 
         index_entry += 1
 
     fetch_res = ctx.gi.tools.run_tool(None, DM_MANUAL_TOOL_ID, manual_dm_params)
-    wait_completion(ctx.gi, fetch_res['outputs'][0]['id'])
+    datasetid=fetch_res['outputs'][0]['id']
+    jobid=None
+    if 'jobs' in fetch_res :
+      jobid=fetch_res['jobs'][0]['id']
+    wait_completion(ctx.gi, datasetid, jobid)
 
     # Reload all tables just in case
     time.sleep(1)  # Reloading too soon might not work for some strange reason

--- a/biomaj2galaxy/commands/add.py
+++ b/biomaj2galaxy/commands/add.py
@@ -98,7 +98,7 @@ def add(ctx, files, dbkey, dbkey_display_name, genome_fasta, genome_fasta_name, 
         'bwa': 'bwa_indexes',
         'bwa_mem': 'bwa_mem_indexes',
         'tophat2': 'tophat2_indexes',
-        'star': 'rnastar_index2_versioned',
+        'star': 'rnastar_index2x_versioned',
     }
 
     files_info = []

--- a/biomaj2galaxy/commands/add.py
+++ b/biomaj2galaxy/commands/add.py
@@ -255,7 +255,7 @@ def add(ctx, files, dbkey, dbkey_display_name, genome_fasta, genome_fasta_name, 
     fetch_res = ctx.gi.tools.run_tool(None, DM_MANUAL_TOOL_ID, manual_dm_params)
     datasetid = fetch_res['outputs'][0]['id']
     jobid = None
-    if 'jobs' in fetch_res :
+    if 'jobs' in fetch_res:
         jobid = fetch_res['jobs'][0]['id']
     wait_completion(ctx.gi, datasetid, jobid)
 

--- a/biomaj2galaxy/commands/add.py
+++ b/biomaj2galaxy/commands/add.py
@@ -203,8 +203,8 @@ def add(ctx, files, dbkey, dbkey_display_name, genome_fasta, genome_fasta_name, 
         fetch_res = ctx.gi.tools.run_tool(None, ADD_FASTA_TOOL_ID, params)
         datasetid = fetch_res['outputs'][0]['id']
         jobid = None
-        if 'jobs' in fetch_res :
-          jobid=fetch_res['jobs'][0]['id']
+        if 'jobs' in fetch_res:
+            jobid = fetch_res['jobs'][0]['id']
         wait_completion(ctx.gi, datasetid, jobid)
 
     elif create_dbkey:  # Create the dbkey without ref genome (no len computing)
@@ -253,10 +253,10 @@ def add(ctx, files, dbkey, dbkey_display_name, genome_fasta, genome_fasta_name, 
         index_entry += 1
 
     fetch_res = ctx.gi.tools.run_tool(None, DM_MANUAL_TOOL_ID, manual_dm_params)
-    datasetid=fetch_res['outputs'][0]['id']
-    jobid=None
+    datasetid = fetch_res['outputs'][0]['id']
+    jobid = None
     if 'jobs' in fetch_res :
-      jobid=fetch_res['jobs'][0]['id']
+        jobid = fetch_res['jobs'][0]['id']
     wait_completion(ctx.gi, datasetid, jobid)
 
     # Reload all tables just in case

--- a/biomaj2galaxy/commands/add.py
+++ b/biomaj2galaxy/commands/add.py
@@ -5,6 +5,7 @@ import uuid
 from biomaj2galaxy import pass_context
 from biomaj2galaxy.io import warn
 from biomaj2galaxy.utils import check_input, get_dbkey_entry, wait_completion
+
 import click
 
 
@@ -73,7 +74,7 @@ import click
 )
 @pass_context
 def add(ctx, files, dbkey, dbkey_display_name, genome_fasta, genome_fasta_name, fasta_sorting_method, fasta_custom_sort_list, fasta_custom_sort_handling, no_file_check, star_with_gtf, star_version, no_biomaj_env):
-    """Add data to a Galaxy data table. FILES is a list of path respecting this syntax: data_table_name:/path/to/data:Data name (e.g. "bowtie2:/db/some/where/my_genome:My supercool genome"). You can escape ':' by writing '\:'"""
+    """Add data to a Galaxy data table. FILES is a list of path respecting this syntax: data_table_name:/path/to/data:Data name (e.g. "bowtie2:/db/some/where/my_genome:My supercool genome"). You can escape ':' by writing '\\:'"""
 
     ADD_FASTA_TOOL_ID = 'toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.4'
     DM_MANUAL_TOOL_ID = 'toolshed.g2.bx.psu.edu/repos/iuc/data_manager_manual/data_manager_manual/0.0.2'
@@ -102,7 +103,7 @@ def add(ctx, files, dbkey, dbkey_display_name, genome_fasta, genome_fasta_name, 
 
     files_info = []
     for f in files:
-        f = f.replace("\:", '___colon___')
+        f = f.replace("\\:", '___colon___')
         f_info = f.split(':')
         f_info = [x.replace('___colon___', ':') for x in f_info]
 

--- a/biomaj2galaxy/commands/add_lib.py
+++ b/biomaj2galaxy/commands/add_lib.py
@@ -6,6 +6,7 @@ import os
 
 from biomaj2galaxy import pass_context
 from biomaj2galaxy.utils import add_files, check_existing, check_input, create_tree, get_library, get_roles
+
 import click
 
 

--- a/biomaj2galaxy/commands/init.py
+++ b/biomaj2galaxy/commands/init.py
@@ -6,8 +6,10 @@ from __future__ import print_function
 import os
 
 from bioblend import galaxy
+
 from biomaj2galaxy import config, pass_context
 from biomaj2galaxy.io import info, warn
+
 import click
 
 

--- a/biomaj2galaxy/commands/rm.py
+++ b/biomaj2galaxy/commands/rm.py
@@ -1,6 +1,7 @@
 import time
 
 from biomaj2galaxy import pass_context
+
 import click
 
 

--- a/biomaj2galaxy/commands/rm_lib.py
+++ b/biomaj2galaxy/commands/rm_lib.py
@@ -6,6 +6,7 @@ import os
 
 from biomaj2galaxy import pass_context
 from biomaj2galaxy.utils import find_tree, get_library
+
 import click
 
 

--- a/biomaj2galaxy/config.py
+++ b/biomaj2galaxy/config.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
+
 import os
-import yaml
 
 from bioblend import galaxy
+
+import yaml
 
 
 DEFAULT_CONFIG = {

--- a/biomaj2galaxy/config.py
+++ b/biomaj2galaxy/config.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 import os
-from bioblend import galaxy
 import yaml
+
+from bioblend import galaxy
+
 
 DEFAULT_CONFIG = {
 }

--- a/biomaj2galaxy/io.py
+++ b/biomaj2galaxy/io.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 import click
 
 

--- a/biomaj2galaxy/utils.py
+++ b/biomaj2galaxy/utils.py
@@ -8,6 +8,7 @@ import sys
 import time
 
 from bioblend import ConnectionError
+
 from biomaj2galaxy.io import warn
 
 

--- a/biomaj2galaxy/utils.py
+++ b/biomaj2galaxy/utils.py
@@ -168,7 +168,7 @@ def get_dbkey_entry(gi, dbkey):
             return k
 
 
-def wait_completion(gi, job_id, sleep_time=30, exit_on_error=True):
+def wait_completion(gi, dataset_id, job_id, sleep_time=30, exit_on_error=True):
     error_number = 0
     sleep_time = 10  # Don't wait too much for first try
 
@@ -176,7 +176,7 @@ def wait_completion(gi, job_id, sleep_time=30, exit_on_error=True):
     while True:
         # What's the status of the running job?
         try:
-            dataset_info = gi.datasets.show_dataset(job_id)
+            dataset_info = gi.datasets.show_dataset(dataset_id)
         except ConnectionError:
             error_number += 1
             warn("Could not connect to the Galaxy server, waiting %s seconds before retrying..." % (sleep_time * error_number))
@@ -193,9 +193,9 @@ def wait_completion(gi, job_id, sleep_time=30, exit_on_error=True):
         time.sleep(sleep_time)
         sleep_time = 30
 
-    dataset_info = gi.datasets.show_dataset(job_id)
+    dataset_info = gi.datasets.show_dataset(dataset_id)
     status = dataset_info['state']
-    if exit_on_error and status == 'error':
+    if exit_on_error and status == 'error' and job_id is not None:
         details = gi.jobs.show_job(job_id, full_details=True)
         print("STDOUT content:")
         print(details['stdout'])

--- a/test/dm_test.py
+++ b/test/dm_test.py
@@ -120,7 +120,7 @@ class DmTest(unittest.TestCase):
         twobit = twobit['fields']
         assert [new_dbkey, '/foo/really/foo/bar'] in twobit
 
-        star = self.gi.tool_data.show_data_table('rnastar_index2_versioned')
+        star = self.gi.tool_data.show_data_table('rnastar_index2x_versioned')
         star = star['fields']
         assert [new_dbkey, new_dbkey, 'Wixxxtoo!', '/foo/bloup/test/faa/bor', '0', '0'] in star
 
@@ -136,7 +136,7 @@ class DmTest(unittest.TestCase):
         runner = CliRunner()
         runner.invoke(biomaj2galaxy, ['add', '--dbkey', new_dbkey, '--dbkey-display-name', new_dbkey_name, '--no-file-check', 'star:/foo/bloup/test/faa/bor:Wixxxtoo!', '--star-with-gtf'], catch_exceptions=False)
 
-        star = self.gi.tool_data.show_data_table('rnastar_index2_versioned')
+        star = self.gi.tool_data.show_data_table('rnastar_index2x_versioned')
         star = star['fields']
         assert [new_dbkey, new_dbkey, 'Wixxxtoo!', '/foo/bloup/test/faa/bor', '1', '0'] in star
 
@@ -148,7 +148,7 @@ class DmTest(unittest.TestCase):
         runner = CliRunner()
         runner.invoke(biomaj2galaxy, ['add', '--dbkey', new_dbkey, '--dbkey-display-name', new_dbkey_name, '--no-file-check', 'star:/foo/bloup/test/faa/bor:Wixxxtoo!', '--star-with-gtf', '--star-version', '1.7.6'], catch_exceptions=False)
 
-        star = self.gi.tool_data.show_data_table('rnastar_index2_versioned')
+        star = self.gi.tool_data.show_data_table('rnastar_index2x_versioned')
         star = star['fields']
         assert [new_dbkey, new_dbkey, 'Wixxxtoo!', '/foo/bloup/test/faa/bor', '1', '1.7.6'] in star
 
@@ -295,7 +295,7 @@ class DmTest(unittest.TestCase):
             'blastdb',
             'twobit',
             '__dbkeys__',
-            'rnastar_index2_versioned',
+            'rnastar_index2x_versioned',
             'bwa_indexes',
             'all_fasta'
         ]
@@ -315,7 +315,7 @@ class DmTest(unittest.TestCase):
             'blastdb',
             'twobit',
             '__dbkeys__',
-            'rnastar_index2_versioned',
+            'rnastar_index2x_versioned',
             'bwa_indexes',
             'all_fasta'
         ]


### PR DESCRIPTION
Galaxy 19.09
Biomaj 3.10
Biomaj2galaxy 2.1.0

The data manager manual is mixing up dataset id and job id probably due to galaxy code evolution ?
It is (now) required here to assigned separetely dataset id and job id otherwise this raised an error were Galaxy is looking for a job_id that refers to a dataset_id

